### PR TITLE
Add e2e tests for open banking transaction suggestions

### DIFF
--- a/e2e/lib/fixtures/cleanup.ts
+++ b/e2e/lib/fixtures/cleanup.ts
@@ -9,6 +9,9 @@ interface IDRow extends RowDataPacket {
 // cleanupForUserLogins, in dependency order: rows referencing other
 // rows are deleted first.
 const USER_TABLES_BY_USER_ID = [
+  'OpenBankingFetchTransaction',
+  'OpenBankingFetch',
+  'OpenBankingTransaction',
   'ExternalAccountMapping',
   'BankAccount',
   'LedgerAccount',

--- a/e2e/lib/fixtures/constants.ts
+++ b/e2e/lib/fixtures/constants.ts
@@ -12,3 +12,7 @@ export const DEFAULT_TEST_CURRENCY = 'USD';
 // (or stock share) and its nano representation. Used everywhere the
 // fixtures compose amount columns.
 export const NANOS_PER_DOLLAR = 1_000_000_000;
+
+// OPEN_BANKING_PROVIDER is the provider stamped onto seeded open banking
+// fetches. The value is the proto Provider enum name the backend records.
+export const OPEN_BANKING_PROVIDER = 'PROVIDER_GOCARDLESS';

--- a/e2e/lib/fixtures/factory.ts
+++ b/e2e/lib/fixtures/factory.ts
@@ -1,4 +1,5 @@
 import * as bcrypt from 'bcrypt';
+import {createHash} from 'crypto';
 import {RowDataPacket} from 'mysql2/promise';
 // eslint-plugin-import's resolver doesn't follow uuid 14's conditional exports.
 // eslint-disable-next-line import/named
@@ -9,6 +10,7 @@ import {
   Bank,
   BankAccount,
   Category,
+  OpenBankingTransactionSeed,
   Stock,
   StockKey,
   Tag,
@@ -26,6 +28,7 @@ export type {
   Bank,
   BankAccount,
   Category,
+  OpenBankingTransactionSeed,
   Stock,
   Tag,
   TestDataBundle,
@@ -36,6 +39,7 @@ export type {
 import {
   DEFAULT_TEST_CURRENCY,
   NANOS_PER_DOLLAR,
+  OPEN_BANKING_PROVIDER,
   TEST_USER_PASSWORD,
 } from './constants';
 
@@ -780,6 +784,78 @@ export class TestFactory {
        VALUES (?, ?, ?, ?)`,
       [userId, sourceTransactionId, linkedTransactionId, linkType]
     );
+  }
+
+  // openBankingTransactions makes the given transactions appear as open
+  // banking suggestions for an account. It links the bank account to an
+  // external account, records a successful fetch, and stores the
+  // transactions against that fetch — the same chain the provider sync
+  // produces. Call it once per account; for a transfer suggestion seed the
+  // matching withdrawal and deposit on their respective accounts.
+  async openBankingTransactions({
+    user,
+    bank,
+    account,
+    transactions,
+    externalAccountId,
+    provider,
+  }: {
+    user: {id: number};
+    bank: {id: number};
+    account: {id: number};
+    transactions: OpenBankingTransactionSeed[];
+    externalAccountId?: string;
+    provider?: string;
+  }): Promise<void> {
+    const externalAccount = externalAccountId ?? `ext-account-${account.id}`;
+    await exec(
+      `INSERT INTO ExternalAccountMapping (userId, internalAccountId, externalAccountId, bankId)
+       VALUES (?, ?, ?, ?)`,
+      [user.id, account.id, externalAccount, bank.id]
+    );
+    const now = new Date();
+    const fetchId = await insert(
+      `INSERT INTO OpenBankingFetch
+         (userId, internalAccountId, provider, \`trigger\`, status, txCount, startedAt, finishedAt)
+       VALUES (?, ?, ?, 'MANUAL', 'SUCCESS', ?, ?, ?)`,
+      [
+        user.id,
+        account.id,
+        provider ?? OPEN_BANKING_PROVIDER,
+        transactions.length,
+        now,
+        now,
+      ]
+    );
+    for (const t of transactions) {
+      const time = t.timestamp ? new Date(t.timestamp) : now;
+      const signedAmountNanos = BigInt(Math.round(t.amount * NANOS_PER_DOLLAR));
+      const raw = JSON.stringify({
+        externalId: t.externalId,
+        description: t.description,
+        amount: t.amount,
+      });
+      const rawHash = createHash('sha256').update(raw).digest('hex');
+      const txId = await insert(
+        `INSERT INTO OpenBankingTransaction
+           (userId, externalTransactionId, timestamp, description, signedAmountNanos, raw, rawHash)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          user.id,
+          t.externalId,
+          time,
+          t.description,
+          signedAmountNanos.toString(),
+          raw,
+          rawHash,
+        ]
+      );
+      await exec(
+        `INSERT INTO OpenBankingFetchTransaction (userId, fetchId, openBankingTransactionId)
+         VALUES (?, ?, ?)`,
+        [user.id, fetchId, txId]
+      );
+    }
   }
 }
 

--- a/e2e/lib/fixtures/types.ts
+++ b/e2e/lib/fixtures/types.ts
@@ -55,3 +55,14 @@ export type TransactionContext = {
   account: {id: number};
   category: {id: number};
 };
+
+// OpenBankingTransactionSeed is one transaction as an open banking provider
+// would report it. `amount` is in whole currency units and signed: a negative
+// value is money leaving the account (a withdrawal), a positive value money
+// arriving (a deposit).
+export type OpenBankingTransactionSeed = {
+  externalId: string;
+  description: string;
+  amount: number;
+  timestamp?: Date | string;
+};

--- a/e2e/pages/NewTransactionPage.ts
+++ b/e2e/pages/NewTransactionPage.ts
@@ -1,16 +1,47 @@
-import {type Page} from '@playwright/test';
+import {type Locator, type Page, expect} from '@playwright/test';
 import {TransactionForm} from './TransactionForm';
 
 export class NewTransactionPage {
   readonly page: Page;
   readonly form: TransactionForm;
+  readonly suggestions: SuggestionList;
 
   constructor(page: Page) {
     this.page = page;
     this.form = new TransactionForm(page.locator('form'));
+    this.suggestions = new SuggestionList(page);
   }
 
   async goto() {
     await this.page.goto('/new');
+  }
+}
+
+// SuggestionList drives the open banking suggestion panel shown above the new
+// transaction form. Each suggestion is keyed by the description the provider
+// reported; clicking one pre-fills the form.
+export class SuggestionList {
+  readonly page: Page;
+  readonly heading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', {name: 'Suggestions'});
+  }
+
+  // selectAccount switches the panel to the account whose suggestions should
+  // be shown, identified by its full "Bank: Account" name.
+  async selectAccount(fullAccountName: string) {
+    await this.page.getByRole('button', {name: fullAccountName}).click();
+  }
+
+  item(description: string): Locator {
+    return this.page.getByText(description, {exact: true});
+  }
+
+  async click(description: string) {
+    const item = this.item(description);
+    await expect(item).toBeVisible();
+    await item.click();
   }
 }

--- a/e2e/specs/txform/open-banking.spec.ts
+++ b/e2e/specs/txform/open-banking.spec.ts
@@ -1,0 +1,167 @@
+import {expect, test} from '../../lib/fixtures/test-base';
+import {NewTransactionPage} from '../../pages/NewTransactionPage';
+import {OverviewPage} from '../../pages/OverviewPage';
+import {TransactionListPage} from '../../pages/TransactionListPage';
+
+test.describe('Create transactions from open banking data', () => {
+  test('expense from a withdrawal suggestion', async ({
+    page,
+    seed,
+    loginAs,
+  }) => {
+    const {user, bank, account, category} = await seed.createUserWithTestData({
+      bank: {name: 'HSBC'},
+      account: {name: 'Current', initialBalance: 1000},
+      category: {name: 'Groceries'},
+    });
+    await seed.openBankingTransactions({
+      user,
+      bank,
+      account,
+      transactions: [
+        {
+          externalId: 'ob-wf-1',
+          description: 'Whole Foods Market',
+          amount: -52.4,
+        },
+        {externalId: 'ob-shell-1', description: 'Shell', amount: -60},
+      ],
+    });
+    await loginAs(user);
+
+    const addTxPage = new NewTransactionPage(page);
+    await addTxPage.goto();
+    await addTxPage.suggestions.click('Whole Foods Market');
+    // The withdrawal pre-fills an expense with its amount and description.
+    await expect(addTxPage.form.amountInput).toHaveValue('52.4');
+    await expect(addTxPage.form.vendorInput).toHaveValue('Whole Foods Market');
+    await addTxPage.form.submit();
+
+    const listPage = new TransactionListPage(page);
+    await listPage.goto();
+    await listPage.expectExpenseTransaction('Whole Foods Market', {
+      amount: '$52.40',
+      vendor: 'Whole Foods Market',
+      account: 'HSBC: Current',
+      category: 'Groceries',
+    });
+
+    const overviewPage = new OverviewPage(page);
+    await overviewPage.goto();
+    await overviewPage.expectAccountBalance('HSBC', 'Current', '$947.60');
+    await overviewPage.expectTotalBalance('$948');
+  });
+
+  test('income from a deposit suggestion', async ({page, seed, loginAs}) => {
+    const {user, bank, account, category} = await seed.createUserWithTestData({
+      bank: {name: 'Barclays'},
+      account: {name: 'Current', initialBalance: 1000},
+      category: {name: 'Salary'},
+    });
+    await seed.openBankingTransactions({
+      user,
+      bank,
+      account,
+      transactions: [
+        {externalId: 'ob-pay-1', description: 'ACME PAYROLL', amount: 2500},
+        {externalId: 'ob-int-1', description: 'Interest', amount: 12.3},
+      ],
+    });
+    await loginAs(user);
+
+    const addTxPage = new NewTransactionPage(page);
+    await addTxPage.goto();
+    await addTxPage.suggestions.click('ACME PAYROLL');
+    // The deposit pre-fills an income with its amount and payer.
+    await expect(addTxPage.form.amountInput).toHaveValue('2500');
+    await expect(addTxPage.form.payerInput).toHaveValue('ACME PAYROLL');
+    await addTxPage.form.submit();
+
+    const listPage = new TransactionListPage(page);
+    await listPage.goto();
+    await listPage.expectIncomeTransaction('ACME PAYROLL', {
+      amount: '$2,500',
+      payer: 'ACME PAYROLL',
+      account: 'Barclays: Current',
+      category: 'Salary',
+    });
+
+    const overviewPage = new OverviewPage(page);
+    await overviewPage.goto();
+    await overviewPage.expectAccountBalance('Barclays', 'Current', '$3,500');
+    await overviewPage.expectTotalBalance('$3,500');
+  });
+
+  test('transfer from matching withdrawal and deposit suggestions', async ({
+    page,
+    seed,
+    loginAs,
+  }) => {
+    const {
+      user,
+      bank,
+      account: current,
+    } = await seed.createUserWithTestData({
+      bank: {name: 'Monzo'},
+      account: {name: 'Current', initialBalance: 500, displayOrder: 0},
+      category: {name: 'Transfers'},
+    });
+    const savings = await seed.createAccount(user.id, bank.id, {
+      name: 'Savings',
+      initialBalance: 100,
+      displayOrder: 1,
+    });
+    // Both legs share the same instant so transfer detection pairs them.
+    const movedAt = new Date();
+    await seed.openBankingTransactions({
+      user,
+      bank,
+      account: current,
+      transactions: [
+        {
+          externalId: 'ob-out-1',
+          description: 'Transfer to savings',
+          amount: -200,
+          timestamp: movedAt,
+        },
+      ],
+    });
+    await seed.openBankingTransactions({
+      user,
+      bank,
+      account: savings,
+      transactions: [
+        {
+          externalId: 'ob-in-1',
+          description: 'Transfer from current',
+          amount: 200,
+          timestamp: movedAt,
+        },
+      ],
+    });
+    await loginAs(user);
+
+    const addTxPage = new NewTransactionPage(page);
+    await addTxPage.goto();
+    await addTxPage.suggestions.click('Transfer to savings');
+    // The paired legs pre-fill a transfer between the two accounts.
+    await expect(addTxPage.form.amountInput).toHaveValue('200');
+    await addTxPage.form.submit();
+
+    const listPage = new TransactionListPage(page);
+    await listPage.goto();
+    await listPage.expectTransferTransaction('$200', {
+      accountFrom: 'Monzo: Current',
+      accountTo: 'Monzo: Savings',
+      amountSent: '$200',
+      amountReceived: '$200',
+      category: 'Transfers',
+    });
+
+    const overviewPage = new OverviewPage(page);
+    await overviewPage.goto();
+    await overviewPage.expectAccountBalance('Monzo', 'Current', '$300');
+    await overviewPage.expectAccountBalance('Monzo', 'Savings', '$300');
+    await overviewPage.expectTotalBalance('$600');
+  });
+});

--- a/e2e/specs/txform/open-banking.spec.ts
+++ b/e2e/specs/txform/open-banking.spec.ts
@@ -9,7 +9,7 @@ test.describe('Create transactions from open banking data', () => {
     seed,
     loginAs,
   }) => {
-    const {user, bank, account, category} = await seed.createUserWithTestData({
+    const {user, bank, account} = await seed.createUserWithTestData({
       bank: {name: 'HSBC'},
       account: {name: 'Current', initialBalance: 1000},
       category: {name: 'Groceries'},
@@ -53,7 +53,7 @@ test.describe('Create transactions from open banking data', () => {
   });
 
   test('income from a deposit suggestion', async ({page, seed, loginAs}) => {
-    const {user, bank, account, category} = await seed.createUserWithTestData({
+    const {user, bank, account} = await seed.createUserWithTestData({
       bank: {name: 'Barclays'},
       account: {name: 'Current', initialBalance: 1000},
       category: {name: 'Salary'},


### PR DESCRIPTION
This PR adds end-to-end tests for the open banking transaction suggestion feature, along with supporting test infrastructure.

## Summary
Adds comprehensive e2e test coverage for creating transactions from open banking data, including expenses, income, and transfers. Introduces a new `openBankingTransactions` seeding method to the test factory that simulates the full chain of open banking provider syncs.

## Key Changes

- **New e2e test suite** (`e2e/specs/txform/open-banking.spec.ts`):
  - Tests expense creation from withdrawal suggestions
  - Tests income creation from deposit suggestions
  - Tests transfer creation from paired withdrawal/deposit suggestions across accounts
  - Validates form pre-filling, transaction list display, and account balance updates

- **Test factory enhancements** (`e2e/lib/fixtures/factory.ts`):
  - Added `openBankingTransactions()` method to seed open banking data
  - Creates external account mappings, fetch records, and transaction records matching the provider sync chain
  - Supports custom timestamps for transfer detection testing

- **Page object improvements** (`e2e/pages/NewTransactionPage.ts`):
  - Added `SuggestionList` class to interact with the open banking suggestions panel
  - Supports account selection and clicking suggestions to pre-fill forms

- **Test infrastructure** (`e2e/lib/fixtures/`):
  - Added `OpenBankingTransactionSeed` type for seeding transactions
  - Added `OPEN_BANKING_PROVIDER` constant for provider identification
  - Updated cleanup to remove open banking tables in dependency order

## Implementation Details

The `openBankingTransactions` seeding method replicates the exact database state that a provider sync produces: it creates an `ExternalAccountMapping`, an `OpenBankingFetch` record, individual `OpenBankingTransaction` records with SHA256 hashes of the raw data, and links them via `OpenBankingFetchTransaction`. This allows tests to verify the full suggestion flow without mocking the provider integration.

https://claude.ai/code/session_019rRuvB9wmJxG5Frrp4kT8n