### PR TITLE
Show +/- sign on open banking suggestion amounts

### DIFF
--- a/frontend/components/txform/NewTransactionSuggestions.tsx
+++ b/frontend/components/txform/NewTransactionSuggestions.tsx
@@ -368,6 +368,7 @@ function SuggestionItem({
               'text-green-900': singleOpProto.type == 'deposit',
             })}
           >
+            {singleOpProto.type == 'deposit' ? '+' : '-'}
             {formatUnit(unit, nanosToDollar(singleOpProto.absoluteAmountNanos))}
           </div>
         </div>


### PR DESCRIPTION
## Summary

In the open banking suggestions list, amounts were rendered as bare absolute values, so income (deposits) and withdrawals looked identical apart from colour. This prefixes each amount with a sign:

- `+` for deposits (income)
- `-` for withdrawals

## Changes

- `frontend/components/txform/NewTransactionSuggestions.tsx`: prefix the formatted amount with the operation's sign in `SuggestionItem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nc3aLtxYShNaqCUcjDVA46)_