### PR TITLE
Remove zero-amount transactions from suggestions

### DIFF
--- a/frontend/lib/openbanking/context.tsx
+++ b/frontend/lib/openbanking/context.tsx
@@ -57,9 +57,9 @@ export const useOpenBankingTransactions = () => {
     }
   );
   const transactions = data?.accounts.flatMap(acc =>
-    acc.transactions.map(t =>
-      fromOpenBankingTransaction(t, acc.internalAccountId)
-    )
+    acc.transactions
+      .filter(t => t.signedAmountNanos !== 0n)
+      .map(t => fromOpenBankingTransaction(t, acc.internalAccountId))
   );
   // Epoch millis of each account's most recent successful fetch, keyed by
   // internal account id. Accounts that have never been fetched are absent.


### PR DESCRIPTION
## Summary

Zero-amount open banking transactions (e.g. the `Human Forest £0.00` entry in the new transaction suggestions) were appearing in the suggestions list. These can't actually be used: the transaction prototype schema requires a positive `absoluteAmountNanos`, so selecting one would fail validation on submit.

This filters them out at the source in `useOpenBankingTransactions`, dropping any transaction with `signedAmountNanos === 0n` before it's converted to a prototype.

## Changes

- `frontend/lib/openbanking/context.tsx`: skip zero-amount transactions when building the suggestion list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015NrZe2i2DKn6jvpzDhSk8n)_