### PR TITLE
test(e2e): cover vendor naming for open banking expenses

### DIFF
--- a/e2e/lib/fixtures/factory.ts
+++ b/e2e/lib/fixtures/factory.ts
@@ -786,6 +786,29 @@ export class TestFactory {
     );
   }
 
+  // recordTransactionPrototype links an open banking transaction, identified
+  // by its external id and the description the provider reported, to the
+  // internal transaction a user created from it. This is the history the new
+  // transaction form mines to pre-fill the vendor of future suggestions that
+  // share the same external description.
+  async recordTransactionPrototype({
+    userId,
+    externalId,
+    externalDescription,
+    internalTransactionId,
+  }: {
+    userId: number;
+    externalId: string;
+    externalDescription: string;
+    internalTransactionId: number;
+  }): Promise<void> {
+    await exec(
+      `INSERT INTO TransactionPrototype (userId, externalId, externalDescription, internalTransactionId)
+       VALUES (?, ?, ?, ?)`,
+      [userId, externalId, externalDescription, internalTransactionId]
+    );
+  }
+
   // openBankingTransactions makes the given transactions appear as open
   // banking suggestions for an account. It links the bank account to an
   // external account, records a successful fetch, and stores the

--- a/e2e/specs/txform/open-banking.spec.ts
+++ b/e2e/specs/txform/open-banking.spec.ts
@@ -65,6 +65,97 @@ test.describe('Create transactions from open banking data', () => {
     });
   });
 
+  test('expense vendor renamed from a raw suggestion description', async ({
+    page,
+    seed,
+    loginAs,
+  }) => {
+    const {user, bank, account} = await seed.createUserWithTestData({
+      bank: {name: 'HSBC'},
+      account: {name: 'Current', initialBalance: 1000},
+      category: {name: 'Coffee'},
+    });
+    await seed.openBankingTransactions({
+      user,
+      bank,
+      account,
+      transactions: [
+        {externalId: 'ob-zettle-1', description: 'Zettle *Starbu', amount: -45},
+      ],
+    });
+    await loginAs(user);
+    const addTxPage = new NewTransactionPage(page);
+    await addTxPage.goto();
+    // With no prior history the suggestion shows the provider's raw description,
+    // which pre-fills the vendor and the user cleans up before recording.
+    await addTxPage.suggestions.click('Zettle *Starbu');
+    await addTxPage.form.vendorInput.fill('Starbucks');
+    await addTxPage.form.submit();
+    const listPage = new TransactionListPage(page);
+    await listPage.goto();
+    await listPage.expectExpenseTransaction('Starbucks', {
+      amount: '$45',
+      vendor: 'Starbucks',
+      account: 'HSBC: Current',
+      category: 'Coffee',
+    });
+  });
+
+  test('expense vendor pre-filled from a prior recording', async ({
+    page,
+    seed,
+    loginAs,
+  }) => {
+    const {user, bank, account, category} = await seed.createUserWithTestData({
+      bank: {name: 'HSBC'},
+      account: {name: 'Current', initialBalance: 1000},
+      category: {name: 'Coffee'},
+    });
+    // A 'Zettle *Starbu' open banking transaction was previously recorded as a
+    // Starbucks expense, captured here as the prototype linking the two.
+    const prior = await seed.expense('Starbucks', 80, {
+      user,
+      account,
+      category,
+      timestamp: '2025-01-02T09:00',
+    });
+    await seed.recordTransactionPrototype({
+      userId: user.id,
+      externalId: 'ob-zettle-old',
+      externalDescription: 'Zettle *Starbu',
+      internalTransactionId: prior.id,
+    });
+    await seed.openBankingTransactions({
+      user,
+      bank,
+      account,
+      transactions: [
+        {
+          externalId: 'ob-zettle-new',
+          description: 'Zettle *Starbu',
+          amount: -45,
+        },
+      ],
+    });
+    await loginAs(user);
+    const addTxPage = new NewTransactionPage(page);
+    await addTxPage.goto();
+    // The prior recording rewrites the suggestion to the learned vendor, so the
+    // user records it without retyping the name.
+    await addTxPage.suggestions.click('Starbucks');
+    await addTxPage.form.submit();
+    const listPage = new TransactionListPage(page);
+    await listPage.goto();
+    // Both Starbucks expenses share a vendor, so the new one is found by its
+    // distinct amount.
+    await listPage.expectExpenseTransaction('$45', {
+      amount: '$45',
+      vendor: 'Starbucks',
+      account: 'HSBC: Current',
+      category: 'Coffee',
+    });
+  });
+
   test('transfer from matching withdrawal and deposit suggestions', async ({
     page,
     seed,


### PR DESCRIPTION
## Summary

Adds two e2e cases to the open banking transaction form spec covering how a suggestion's description becomes the recorded vendor.

- **No prior history**: the suggestion shows the provider's raw description (`Zettle *Starbu`), which pre-fills the vendor field. The user renames it to `Starbucks` and records the expense.
- **Prior recording exists**: a seeded `TransactionPrototype` links the external description `Zettle *Starbu` to a previously recorded `Starbucks` expense. The new-transaction form mines this history (`fillMostCommonDescriptions`) and rewrites the suggestion to `Starbucks`, so it records as `Starbucks` without the user retyping.

## Changes

- `e2e/lib/fixtures/factory.ts`: new `recordTransactionPrototype` fixture to seed the external→internal transaction link the second case depends on.
- `e2e/specs/txform/open-banking.spec.ts`: the two new tests.

## Testing

- `tsc --noEmit` passes; Prettier passes.
- The full Playwright suite was not run here — this environment has no Docker, which the suite requires for the MySQL container and the built backend/frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dki8KR6VFKpiq9Ny2jCuNr)_